### PR TITLE
fix(install.js): use platform specific command to spawn npm install

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -13,7 +13,7 @@ if (gmInstalled()) {
 
 console.log("Installing lwip. If this fails, just install GraphicsMagick (http://www.graphicsmagick.org/).");
 let npmCmd = /^win/.test(process.platform) ? "npm.cmd" : "npm";
-let proc = childProcess.spawn(npmCmd, ["i", "lwip@0.0.8"], { cwd: `${__dirname}/..` });
+let proc = childProcess.spawn(npmCmd, ["i", "lwip@0.0.9"], { cwd: `${__dirname}/..` });
 
 proc.stdout.pipe(process.stdout);
 proc.stderr.pipe(process.stderr);

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,7 +12,8 @@ if (gmInstalled()) {
 }
 
 console.log("Installing lwip. If this fails, just install GraphicsMagick (http://www.graphicsmagick.org/).");
-let proc = childProcess.spawn("npm", ["i", "lwip@0.0.8"], { cwd: `${__dirname}/..` });
+let npmCmd = /^win/.test(process.platform) ? "npm.cmd" : "npm";
+let proc = childProcess.spawn(npmCmd, ["i", "lwip@0.0.8"], { cwd: `${__dirname}/..` });
 
 proc.stdout.pipe(process.stdout);
 proc.stderr.pipe(process.stderr);


### PR DESCRIPTION
fixes #13 

But still can't install because lwip@0.0.8 fails to install on windows (Win8.1, node 6.10).

Tried installing `lwip@0.0.9` which works fine. If you're ok with updating `lwip` I will add a commit to specify `lwip@0.0.9`.